### PR TITLE
Process All slots, and use keywords for identify armors

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,6 +59,9 @@
           "enableMicrosoftCodeAnalysis": true,
           "enableClangTidyCodeAnalysis": true
         }
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl.exe"
       }
     },
     {

--- a/src/Events.cpp
+++ b/src/Events.cpp
@@ -57,6 +57,11 @@ static void ShuffleSlots(std::array<RE::BGSBipedObjectForm::BipedObjectSlot, 4> 
 	std::shuffle(slots->begin(), slots->end(), mt);
 }
 
+static void ShuffleSlots(std::vector<RE::BGSBipedObjectForm::BipedObjectSlot>* slots) {
+    std::lock_guard<std::mutex> guard(lock_mt);
+    std::shuffle(slots->begin(), slots->end(), mt);
+}
+
 static double GetRandom(double a, double b) {
 	std::uniform_real_distribution<> score(a, b);
 	std::lock_guard<std::mutex> guard(lock_mt);
@@ -200,12 +205,56 @@ public:
 
 						// Decay armor, amrmor slots are shuffled for decay loss
 						} else {
-							std::array<RE::BGSBipedObjectForm::BipedObjectSlot, 4> slots = { RE::BGSBipedObjectForm::BipedObjectSlot::kHead, RE::BGSBipedObjectForm::BipedObjectSlot::kBody, RE::BGSBipedObjectForm::BipedObjectSlot::kHands, RE::BGSBipedObjectForm::BipedObjectSlot::kFeet };
-							ShuffleSlots(&slots);
+                            /*std::array<RE::BGSBipedObjectForm::BipedObjectSlot, 4> slots = { 
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kHead, 
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kBody, 
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kHands, 
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kFeet
+                            };
+							ShuffleSlots(&slots);*/
+
+                            std::vector<RE::BGSBipedObjectForm::BipedObjectSlot> slots = {
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kHead,
+                                //RE::BGSBipedObjectForm::BipedObjectSlot::kHair,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kBody,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kHands,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kForearms,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kAmulet,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kRing,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kFeet,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kCalves,
+                                //RE::BGSBipedObjectForm::BipedObjectSlot::kShield,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kTail,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kLongHair,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kCirclet,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kEars,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModMouth,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModNeck,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModChestPrimary,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModBack,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModMisc1,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModPelvisPrimary,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kDecapitateHead,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kDecapitate,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModPelvisSecondary,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModLegRight,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModLegLeft,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModFaceJewelry,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModChestSecondary,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModShoulder,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModArmLeft,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModArmRight,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kModMisc2,
+                                RE::BGSBipedObjectForm::BipedObjectSlot::kFX01
+                            };
+                            ShuffleSlots(&slots);
 
 							for (RE::BGSBipedObjectForm::BipedObjectSlot slot : slots) {
 								FoundEquipData eqD_armor = FoundEquipData::FindEquippedArmor(exChanges, slot);
 								if (eqD_armor.pForm) {
+                                    logger::info("TemperDecay <{:08X}:{}> => <{:08X}:{}> health={}", actor->GetFormID(),
+                                                 actor->GetName(), eqD_armor.pForm->GetFormID(),
+                                                 eqD_armor.pForm->GetName(), eqD_armor.GetItemHealthPercent());
 									TemperDecay(eqD_armor, actor, (a_event->flags & RE::TESHitEvent::Flag::kPowerAttack) != RE::TESHitEvent::Flag::kNone);
 									break;
 								} else if (slot == RE::BGSBipedObjectForm::BipedObjectSlot::kHead) {

--- a/src/FoundEquipData.cpp
+++ b/src/FoundEquipData.cpp
@@ -210,6 +210,9 @@ bool FoundEquipData::CanBreak() {
 			return false;
 		else if (pForm->IsArmor() && pForm->As<RE::TESObjectARMO>()->HasKeyword(utility->keywordMagicDisallow))
 			return false;
+        if (pForm->IsArmor() && pForm->As<RE::TESObjectARMO>()->ContainsKeywordString("zad_Lockable")) {
+            return false;
+        }
 	}
 
 	// Unarmed

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,18 +1,23 @@
 {
-    "registries": [
-      {
-        "kind": "git",
-        "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
-        "baseline": "1b279b20c7e0db1c9d549ff3b64e024c01317b55",
-        "packages": [
-          "articuno",
-          "bethesda-skyrim-scripts",
-          "commonlibsse-ng",
-          "commonlibsse-ng-ae",
-          "gluino",
-          "script-extender-common",
-          "skse"
-        ]
-      }
-    ]
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg.git",
+    "baseline": "cc288af760054fa489574bd8e22d05aa8fa01e5c"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
+      "baseline": "1b279b20c7e0db1c9d549ff3b64e024c01317b55",
+      "packages": [
+        "articuno",
+        "bethesda-skyrim-scripts",
+        "commonlibsse-ng",
+        "commonlibsse-ng-ae",
+        "gluino",
+        "script-extender-common",
+        "skse"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
It is not for merge, but for discussion experimental adoptations for my gameplay. What you thinking about this?

1. `FoundEquipData::FindEquippedArmor` - Checking and filtering by keywords allow process only items, which marked as armors
2. process all slots (not only kHead/Body/Feet/Hand)